### PR TITLE
Fix token length check in admin

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -174,8 +174,9 @@
                 obj[$this.attr('id')] = $this.val();
             }
         });
-        if (obj.token.replace(/\s/g, '').length !== 32) {
-            showMessage(_('Invalid token length. Expected 32 HEX chars'));
+        var tokenLength = obj.token.replace(/\s/g, '').length;
+        if (tokenLength !== 32 && tokenLength !== 96) {
+            showMessage(_('Invalid token length. Expected 32 or 96 HEX chars.'));
             return;
         }
 

--- a/admin/words.js
+++ b/admin/words.js
@@ -37,5 +37,8 @@ systemDictionary = {
     "en": "Send own commands:",
     "de": "Sende eigene Kommandos:",
     "ru": "Send own commands:"
+  },
+  "Invalid token length. Expected 32 or 96 HEX chars.": {
+    "de": "Ungültige Tokenlänge. 32 oder 96 HEX-Zeichen erwartet."   
   }
 };


### PR DESCRIPTION
0.5.8 added support for the 96-char encrypted token of iOS. This check in the admin wasn't updated.