### PR TITLE
Resume paused zoneClean etc.

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,6 +220,9 @@ Sorry, not yet finished.
 - Widget at the time without function
 
 ## Changelog
+### 1.1.4 (2018-08-24)
+* (BuZZy1337) Added possibility to resume a paused zoneclean (State: mihome-vacuum.X.control.resumeZoneClean)
+
 ### 1.1.3 (2018-07-11)
 * (BuZZy1337) fixed zoneCleanup state not working (vacuum was only leaving the dock, saying "Finished ZoneCleanup", and returned immediately back to the dock)
 

--- a/README_de.md
+++ b/README_de.md
@@ -208,6 +208,9 @@ Zur Zeit leider noch nicht fertig.
 - Widget zur Zeit ohne Funktion
 
 ## Changelog
+### 1.1.4 (2018-08-24)
+* (BuZZy1337) Funktion zum Fortsetzen einer vorher pausierten Zonenreinigung hinzugefügt. (State: mihome-vacuum.X.control.resumeZoneClean)
+
 ### 1.1.3 (2018-07-11)
 * (BuZZy1337) Fehler im ZoneCleanup state behoben (Roboter fuhr nur kurz von der Ladestation, meldete "Zonecleanup Finished" und fuhr sofort wieder zurück zur Ladestation)
 

--- a/io-package.json
+++ b/io-package.json
@@ -1,8 +1,19 @@
 {
     "common": {
         "name": "mihome-vacuum",
-        "version": "1.1.3",
+        "version": "1.1.4",
         "news": {
+            "1.1.4": {
+                "en": "added possibility to resume zone cleaning",
+                "de": "Möglichkeit zur Fortsetzung der Zonenreinigung hinzugefügt",
+                "ru": "добавлена ​​возможность возобновить очистку зоны",
+                "pt": "possibilidade adicionada para retomar a limpeza da zona",
+                "nl": "mogelijkheid toegevoegd om zone-schoonmaak te hervatten",
+                "fr": "possibilité de reprendre le nettoyage de la zone",
+                "it": "aggiunta possibilità di riprendere la pulizia delle zone",
+                "es": "posibilidad añadida de reanudar la limpieza de zonas",
+                "pl": "dodano możliwość wznowienia czyszczenia strefy"
+            },
             "1.1.3": {
                 "en": "fixed zone cleanup state not working",
                 "de": "Fixed Zone Cleanup State funktioniert nicht",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "iobroker.mihome-vacuum",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "Control your mihome vacuum cleaner with ioBroker",
   "keywords": [
     "ioBroker",


### PR DESCRIPTION
- Added possibility to resume a paused zone cleanup.

- Check if firmware is higher than 3.3.9 (Build 3194) instead of checking if the firmware is exactly 3.3.9 (Build 3194). Otherwise users who skip the firmware 3.3.9 3194 will never get the states for zoneclean and goto.

- Fixed some code errors/typos.